### PR TITLE
Add Option.bindLens function.

### DIFF
--- a/src/Freya.Core/Prelude.fs
+++ b/src/Freya.Core/Prelude.fs
@@ -109,6 +109,9 @@ module Option =
     let mapLens (l: Lens<'a,'b>) : Prism<'a option,'b> =
         Option.map (fst l), snd l >> Option.map
 
+    let bindLens (p : Lens<'a, 'b option>) : Lens<'a option, 'b option> =
+        Option.bind (fst p), snd p >> Option.map
+
 // Constants
 
 /// Literal constants for the values of keys within the OWIN environment,


### PR DESCRIPTION
In working with a lens that's returning an `'a option`, and I would like to combine w/ a lens that is `Lens<'a, 'b option>`, I found a need for an equivalent of `Option.mapLens`, but for one that returns an option.

This adds `Option.bindLens`, but I'm not sure if this is really a perfect name for this function.

Thoughts?